### PR TITLE
- Fix issue https://developer.apple.com/forums/thread/763568 on ios 18

### DIFF
--- a/library/src/iosMain/kotlin/com/final_class/webview_multiplatform_mobile/platform/WebViewPlatformImpl.kt
+++ b/library/src/iosMain/kotlin/com/final_class/webview_multiplatform_mobile/platform/WebViewPlatformImpl.kt
@@ -28,7 +28,7 @@ internal actual fun WebViewPlatformImpl(
     )
 
     if (openInExternalBrowser) {
-        UIApplication.sharedApplication.openURL(url = nsurl)
+        UIApplication.sharedApplication.openURL(url = nsurl, options = emptyMap<Any?, Any?>(), completionHandler = null)
     } else {
         val viewController = UIApplication.sharedApplication.keyWindow?.rootViewController
         viewController?.presentViewController(safariViewController, animated = true, completion = null)


### PR DESCRIPTION
https://developer.apple.com/forums/thread/763568

This pull request updates the `WebViewPlatformImpl` class to enhance the behavior of the `openURL` method when opening a URL in an external browser.

### Enhancements to URL opening behavior:
* [`library/src/iosMain/kotlin/com/final_class/webview_multiplatform_mobile/platform/WebViewPlatformImpl.kt`](diffhunk://#diff-0f684febb4d5a74c7e0ecbfa9f8000b218e4972caf40b6530aa47436e0220bcfL31-R31): Updated the `openURL` method to include `options` and `completionHandler` parameters, providing more flexibility and compatibility with modern iOS APIs.